### PR TITLE
Update buyerBook table

### DIFF
--- a/back_end/table.sql
+++ b/back_end/table.sql
@@ -30,7 +30,7 @@ CREATE TABLE `address` (
 CREATE TABLE `buyerBook` (
     `itemBuyKey` INT AUTO_INCREMENT PRIMARY KEY COMMENT 'PK(구매희망도서)',
     `custKey` INT NOT NULL COMMENT '구매자',
-    `itemTitle` VARCHAR(30) NOT NULL,
+    `itemTitle` VARCHAR(255) NOT NULL,
     `author` VARCHAR(20) NOT NULL,
     `publisher` VARCHAR(20) NOT NULL,
     `itemImg` VARCHAR(600) NULL COMMENT 'NOT NULL 값이지만 테스트를 위해 NULL로 설정 -- 추후 변경',


### PR DESCRIPTION
- 책 제목 길이가 길어 db에 저장되지 않는 오류 수정
   => 책 제목 길이를 기존 VARCHAR 30에서 255로 수정.