### PR TITLE
[fix] 구매하기, 구매내역 페이지 : PurInfoBox 컴포넌트 - 오류수정

### DIFF
--- a/front_end/src/components/DetailConts.js
+++ b/front_end/src/components/DetailConts.js
@@ -1,11 +1,13 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import "../styled/DetailConts.css";
 import SellerRanking from "../components/SellerRanking";
+import axios from "axios";
 
 const DetailConts = ({ productInfo, bookInfo }) => {
   const { price, sellerKey, damage } = productInfo; //판매자 정보 가져오기
   const [showModal, setShowModal] = useState(false); // 판매자 정보 보기 modal - useState
+  const [sellerNickname, setSellerNickname] = useState();
 
   const toggleModal = () => {
     // 판매자 정보 보기 버튼 클릭 시 모달창 띄우기
@@ -18,6 +20,20 @@ const DetailConts = ({ productInfo, bookInfo }) => {
     navigate("/Purchase/");
     window.scrollTo(0, 0); // 페이지 이동 후 화면의 상단으로 스크롤 이동
   };
+  const getSellerNickname = async () => {
+    try {
+      const response = await axios.get(
+        `http://localhost:3001/customers/${sellerKey}`
+      );
+      console.log(response.data.nickname);
+      setSellerNickname(response.data.nickname);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+  useEffect(() => {
+    getSellerNickname();
+  }, [sellerKey]);
 
   return (
     <div className="yhw_detailContsBox">
@@ -27,7 +43,7 @@ const DetailConts = ({ productInfo, bookInfo }) => {
           <div className="yhw_detailContsLTop">
             <b>{price}원</b>
             <span className="yhw_detailContsSeller">
-              판매자 : {sellerKey}
+              판매자 : {sellerNickname}
               {/* 판매자 {seller} &#40;등급 {grade}&#41; */}
             </span>
           </div>

--- a/front_end/src/components/DetailTop.js
+++ b/front_end/src/components/DetailTop.js
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import "../styled/DetailTop.css";
+import axios from "axios";
 
-const DetailTop = ({ bookInfo }) => {
+const DetailTop = ({ bookInfo, buyerNickname }) => {
   return (
     <div className="yhw_detailTopProdBox">
       {" "}
@@ -11,8 +12,11 @@ const DetailTop = ({ bookInfo }) => {
         <img src={bookInfo.itemImg} alt="상품이미지" />
         <div className="yhw_detailTopProdInfoTxt">
           <div className="yhw_detailTopProdInfoTop">
-            <b>{bookInfo.itemTitle}도서명</b>
-            <span>{bookInfo.author}저자</span>
+            <b>{bookInfo.itemTitle}</b>
+            <span>
+              {bookInfo.author} | {bookInfo.publisher}
+            </span>
+            <span className="yhw_detailTopBuyer">구매자 {buyerNickname}</span>
             {/* <span className="yhw_detailTopBuyer">구매자 {loginUser}</span> */}
           </div>
           <div className="yhw_detailTopProdInfoBottom">

--- a/front_end/src/components/PurInfoBox.js
+++ b/front_end/src/components/PurInfoBox.js
@@ -1,16 +1,18 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { Link, useNavigate } from "react-router-dom";
 import "../styled/PurInfoBox.css";
-import usePurInfoData from "../hooks/api/usePurInfoData"; // usePurInfoData 훅 임포트
+// // import usePurInfoData from "../hooks/api/usePurInfoData"; // usePurInfoData 훅 임포트
 
-const PurInfoBox = () => {
-  // usePurInfoData 훅을 호출하여 bookData 상태와 데이터 가져오는 로직 사용
-  const { bookData, fetchBookData } = usePurInfoData();
+// const PurInfoBox = () => {
+//   // usePurInfoData 훅을 호출하여 bookData 상태와 데이터 가져오는 로직 사용
+//   const { bookData, fetchBookData } = usePurInfoData();
 
-  // 컴포넌트 마운트 시 데이터 가져오기
-  useEffect(() => {
-    fetchBookData();
-  }, [fetchBookData]);
+//   // 컴포넌트 마운트 시 데이터 가져오기
+//   useEffect(() => {
+//     fetchBookData();
+//   }, [fetchBookData]);
+const PurInfoBox = ({ bookData }) => {
+  // 구매하기페이지(Purchase)와 구매내역페이지(PurchaseHistory)에서 사용됨
 
   const navigate = useNavigate();
   const convey = () => {

--- a/front_end/src/pages/BuyDetail.js
+++ b/front_end/src/pages/BuyDetail.js
@@ -8,7 +8,6 @@ import StateCategory from "../components/StateCategory";
 import DropDownSort from "../components/DropDownSort";
 import DetailConts from "../components/DetailConts";
 import Footer from "../components/Footer";
-import { productInfosData } from "../asset/productInfosData";
 import axios from "axios";
 
 const BuyDetail = () => {
@@ -17,7 +16,8 @@ const BuyDetail = () => {
   const { itemBuyKey } = useParams();
   const [bookInfo, setBookInfo] = useState([]);
   const [sellerInfo, setSellerInfo] = useState([]);
-  const [sellerNickname, setSellerNickname] = useState([]);
+  const [buyerNickname, setBuyerNickname] = useState();
+
   // 특정 구매희망 도서 가져오기
   const getBookInfo = async () => {
     try {
@@ -41,24 +41,28 @@ const BuyDetail = () => {
       console.error(error);
     }
   };
-  // const getSellerNickname = async () => {
-  //   try {
-  //     const response = await axios.get(
-  //       `http://localhost:3001//customers/${sellerInfo.sellerKey}`
-  //     );
-  //     console.log(response.data);
-  //     setSellerNickname(response.data);
-  //   } catch (error) {
-  //     console.error(error);
-  //   }
-  // };
+
+  const getBuyerNickname = async () => {
+    try {
+      const response = await axios.get(
+        `http://localhost:3001/customers/${bookInfo.custKey}`
+      );
+
+      setBuyerNickname(response.data.nickname);
+    } catch (error) {
+      console.error(error);
+    }
+  };
 
   // 초기 렌더링 시 최상 상태에 해당하는 상품 필터링
   useEffect(() => {
     getBookInfo();
     getSeller();
   }, []);
+
   useEffect(() => {
+    // console.log(bookInfo.custKey, "bookinfo 데이터입니다.");
+    getBuyerNickname();
     handleStateChange("최상");
   }, [sellerInfo]);
 
@@ -84,7 +88,25 @@ const BuyDetail = () => {
     setFilteredProducts(filtered); // 필터링된 상품 업데이트
     console.log(filtered, "필터된 데이터");
   };
-
+  // 카테고리명에 따른 문자열 출력
+  const getCategoryName = (category) => {
+    switch (category) {
+      case "economics":
+        return "경제/경영";
+      case "novels":
+        return "소설/시/희곡";
+      case "comics":
+        return "만화";
+      case "arts":
+        return "예체능";
+      case "science":
+        return "과학";
+      case "essays":
+        return "에세이";
+      default:
+        return "-";
+    }
+  };
   return (
     <>
       <div className="height-container">
@@ -105,7 +127,7 @@ const BuyDetail = () => {
                   <VscChevronRight />
                 </span>
                 <Link to="/">
-                  <span>{bookInfo.category}</span>
+                  <span>{getCategoryName(bookInfo.category)}</span>
                 </Link>
                 <span>
                   <VscChevronRight />
@@ -114,7 +136,7 @@ const BuyDetail = () => {
                   <span>{bookInfo.itemTitle}책제목</span>
                 </Link>
               </div>
-              <DetailTop bookInfo={bookInfo} />
+              <DetailTop bookInfo={bookInfo} buyerNickname={buyerNickname} />
             </div>
             <br />
             <div className="yhw_deailStatCatBox">

--- a/front_end/src/pages/Purchase.js
+++ b/front_end/src/pages/Purchase.js
@@ -7,19 +7,18 @@ import PurDefDestCheck from "../components/DefDestCheck";
 import PurDefDest from "../components/PurDefDest";
 import DestForm from "../components/DestForm";
 import Footer from "../components/Footer";
-import usePurInfoData from '../hooks/api/usePurInfoData'; // usePurInfoData 훅 임포트
+import usePurInfoData from "../hooks/api/usePurInfoData"; // usePurInfoData 훅 임포트
 
 const Purchase = () => {
   const [isChecked, setIsChecked] = useState(false);
-  
+
   // usePurInfoData 훅을 호출하여 bookData 상태와 데이터 가져오는 로직 사용
   const { bookData, fetchBookData } = usePurInfoData();
-  
+
   // 컴포넌트 마운트 시 데이터 가져오기
   useEffect(() => {
     fetchBookData();
   }, [fetchBookData]);
-  
 
   /********************** BuyDetail 페이지의 DetailConts가 아직 연결되지 않아서 제대로 동작하지 않음 **********************/
   const navigate = useNavigate(); // 구매하기 버튼 클릭 시  해당 도서 Purchase 페이지로 이동
@@ -33,30 +32,35 @@ const Purchase = () => {
   return (
     <>
       <div className="height-container">
-      <Header />
+        <Header />
 
-      <div className="yhw_container">
-        <div className="yhw_purTopBorderBottom">
-          <div className="yhw_purTopCont">
-            <b>구매하기</b>
-            <PurInfoBox />
+        <div className="yhw_container">
+          <div className="yhw_purTopBorderBottom">
+            <div className="yhw_purTopCont">
+              <b>구매하기</b>
+              <PurInfoBox bookData={bookData} />
+            </div>
           </div>
-        </div>
-        <div className="yhw_purDefDestCont">
-          <div className="yhw_purDefDestBox">
-            <PurDefDestCheck isChecked={isChecked} setIsChecked={setIsChecked} />
-            <PurDefDest />
+          <div className="yhw_purDefDestCont">
+            <div className="yhw_purDefDestBox">
+              <PurDefDestCheck
+                isChecked={isChecked}
+                setIsChecked={setIsChecked}
+              />
+              <PurDefDest />
+            </div>
           </div>
+          <div className="yhw_destFormDiv">
+            <DestForm isChecked={isChecked} />
+          </div>
+          <button className="yhw_purBtn" onClick={handlePurBtnClick}>
+            구매하기
+          </button>
         </div>
-        <div className="yhw_destFormDiv">
-          <DestForm isChecked={isChecked} />
-        </div>
-        <button className="yhw_purBtn" onClick={handlePurBtnClick}>구매하기</button>
       </div>
-</div>
       <Footer />
     </>
   );
-}
+};
 
 export default Purchase;

--- a/front_end/src/pages/PurchaseHistory.js
+++ b/front_end/src/pages/PurchaseHistory.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState, useContext } from "react";
 import { useNavigate } from "react-router-dom";
 import "../styled/PurchaseHistory.css";
 import Header from "../components/Header";
@@ -6,59 +6,81 @@ import MyPageSide from "../components/MypageSide";
 import DateInquiry from "../components/DateInquiry";
 import PurInfoBox from "../components/PurInfoBox";
 import Footer from "../components/Footer";
-import usePurInfoData from '../hooks/api/usePurInfoData'; // usePurInfoData 훅 임포트
+import usePurInfoData from "../hooks/api/usePurInfoData"; // usePurInfoData 훅 임포트
+import { LoginContext } from "../components/LoginContext";
+import axios from "axios";
 
 const PurchaseHistory = () => {
-  // usePurInfoData 훅을 호출하여 bookData 상태와 데이터 가져오는 로직 사용
-  const { bookData, fetchBookData } = usePurInfoData();
+  const { isLoggedIn, loginUser } = useContext(LoginContext);
+  const [filteredPurLists, setFilteredPurLists] = useState([]); // aucStatus가 1인(=낙찰된) 요소들만 필터링하여 새로운 배열을 생성 후 저장
 
   // 컴포넌트 마운트 시 데이터 가져오기
   useEffect(() => {
-    fetchBookData();
-  }, [fetchBookData]);
+    const fetchData = async () => {
+      try {
+        const response = await axios.get(
+          `http://localhost:3001/buyerbook/${loginUser}`
+        );
+        const buyerbooks = response.data;
+        console.log("사용자의 데이터", buyerbooks);
+        const filteredBuyerbooks = buyerbooks.filter(
+          (request) => request.aucStatus === 1
+        ); // 여기서는 aucStatus가 1인 book 정보를 가져와서 PurInfoBox에 넘겨줌
+        setFilteredPurLists(filteredBuyerbooks);
+      } catch (error) {
+        console.error("Error fetching data:", error);
+      }
+    };
+
+    if (isLoggedIn) {
+      fetchData();
+    }
+  }, [isLoggedIn, loginUser]);
 
   const navigate = useNavigate(); // 구매후기작성 버튼 클릭 시 구매후기작성 페이지로 이동
 
   const handleClick = () => {
-    navigate('/Mypage/PurchaseReview');
+    navigate("/Mypage/PurchaseReview");
   };
 
   return (
     <>
       <div className="height-container">
-      <Header />
+        <Header />
 
-      <div className="yhw_container">
-        <div className="yhw_purHistCont">
-          <div className="yhw_MypageSideAdd">
-            <MyPageSide />
-          </div>
-          <div className="yhw_purHistMainCont">
-            <div className="yhw_purHistTopCont">
-              <b>구매내역</b>
-              <DateInquiry /> {/* 날짜 조회 컴포넌트 일단 대충 만들어둠 */}
+        <div className="yhw_container">
+          <div className="yhw_purHistCont">
+            <div className="yhw_MypageSideAdd">
+              <MyPageSide />
             </div>
-            <div className="yhw_purHistContentsBox">
-              <span className="yhw_purHistContentsDate">{/* 해당 날짜 표시 */}2024-03-15</span>
-              {/* 구매 정보 표시 */}
-              <ul className="yhw_purHistLists">
-                <li>
-                  {bookData.itemImg && ( // bookData가 설정되었는지를 확인
-                    <PurInfoBox bookInfos={bookData} />
-                  )}
-                  <div className="yhw_purHistBtns">
-                    <button onClick={handleClick}>구매 후기 작성</button> {/* 후기 작성 완료 시 버튼 비활성화 기능 추가할 예정 */}
-                  </div>
-                </li>
-              </ul>
+            <div className="yhw_purHistMainCont">
+              <div className="yhw_purHistTopCont">
+                <b>구매내역</b>
+                <DateInquiry /> {/* 날짜 조회 컴포넌트 일단 대충 만들어둠 */}
+              </div>
+              <div className="yhw_purHistContentsBox">
+                <span className="yhw_purHistContentsDate">
+                  {/* 해당 날짜 표시 */}2024-03-15
+                </span>
+                {/* 구매 정보 표시 */}
+                <ul className="yhw_purHistLists">
+                  {filteredPurLists.map((filteredPurList, index) => (
+                    <li key={index}>
+                      <PurInfoBox bookData={filteredPurList} />
+                      <div className="yhw_purHistBtns">
+                        <button onClick={handleClick}>구매 후기 작성</button>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </div>
             </div>
           </div>
         </div>
       </div>
-</div>
       <Footer />
     </>
   );
-}
+};
 
 export default PurchaseHistory;


### PR DESCRIPTION
PR [fix] 구매하기, 구매내역 페이지 : PurInfoBox 컴포넌트 - 오류 수정 #134 수정본

- 구매내역을 정상적으로 받아오지 못해서 구매하기페이지만 커스텀 훅으로 받아오도록 수정
- 구매내역페이지는 useState 사용해서 넘겨줌 +++++(추가)
- 도서상세페이지(BuyDetail)에 상단 네비게이션 부분 카테고리명으로 출력되도록 수정
- DetailTop 컴포넌트에서 구매자 닉네임도 함께 출력되도록 수정
- DetailConts 컴포넌트에서 판매자 닉네임으로 출력되도록 수정