### PR TITLE
[fix] 구매하기,구매내역페이지 : PurInfoBox 데이터 충돌로 인한 분리 및 코드 수정

### DIFF
--- a/front_end/src/components/PurHistInfoBox.js
+++ b/front_end/src/components/PurHistInfoBox.js
@@ -1,0 +1,75 @@
+import React, { useState, useEffect } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import "../styled/PurInfoBox.css";
+import useSellerNickname from "../hooks/api/useSellerNickname";
+import useGetReviews from "../hooks/api/useGetReviews";
+
+const PurHistInfoBox = ({ bookData, orderBookData }) => {
+  // orderBookData가 존재하고 유효한 경우에만 판매자 닉네임을 가져오도록 설정
+  const sellerKey = orderBookData ? orderBookData.sellerKey : null;
+  const sellerNickName = useSellerNickname(sellerKey);
+  const itemKey = orderBookData ? orderBookData.itemKey : null;
+
+  //========== 리뷰값 가져오기 =========//
+  const Reviews = useGetReviews(itemKey); //리뷰값 가져오기
+  // console.log(Reviews);
+
+  const [loading, setLoading] = useState(true);
+  useEffect(() => {
+    // orderBookData가 비어 있지 않으면 로딩 상태를 false로 변경
+    if (orderBookData) {
+      setLoading(false);
+    }
+  }, [orderBookData]);
+
+  // console.log(orderBookData, "전달받은 orderBookData");
+  
+  const navigate = useNavigate();
+
+  const convey = () => {
+    navigate("/SellerInfoPage", {
+      //판매자 정보 페이지로 이동
+      state: {
+        custKey: orderBookData.sellerKey,
+      },
+    });
+  };
+
+  if (loading) {
+    return null; // 로딩 중에는 아무것도 렌더링하지 않음
+  }
+  return (
+    <div className="yhw_purInfoBox">
+      <Link to="/detail">
+        <img src={bookData.itemImg} alt="상품이미지" />
+      </Link>
+      <div className="yhw_purInfoTxt">
+        <div className="yhw_purInfoTxtTop">
+          <b>{bookData.itemTitle}</b>
+          <span className="yhw_purInfoWriterPub">
+            {bookData.author} | {bookData.publisher}
+          </span>
+          <span
+            className="yhw_purInfoSeller"
+            title="판매자 정보 보기"
+            onClick={convey}
+          >
+            판매자: {sellerNickName}
+          </span>
+        </div>
+        <div className="yhw_purInfoTxtBottom">
+          <div className="yhw_purInfoStat">
+            <span>구매 날짜</span>
+            <b>{orderBookData.dateBuy.substring(0, 10)}</b>
+          </div>
+          <div className="yhw_purInfoPrice">
+            <span>판매 입찰가</span>
+            <b>{orderBookData.price}원</b>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PurHistInfoBox;

--- a/front_end/src/components/PurInfoBox.js
+++ b/front_end/src/components/PurInfoBox.js
@@ -1,26 +1,12 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { Link, useNavigate } from "react-router-dom";
 import "../styled/PurInfoBox.css";
-import useSellerNickname from "../hooks/api/useSellerNickname";
-import useGetReviews from "../hooks/api/useGetReviews";
+import usePurInfoData from "../hooks/api/usePurInfoData"; // usePurInfoData 훅 임포트
 
-const PurInfoBox = ({ bookData, orderBookData }) => {
-  // orderBookData가 존재하고 유효한 경우에만 판매자 닉네임을 가져오도록 설정
-  const sellerKey = orderBookData ? orderBookData.sellerKey : null;
-  const sellerNickName = useSellerNickname(sellerKey);
-  const itemKey = orderBookData ? orderBookData.itemKey : null;
-
-  //========== 리뷰값 가져오기 =========//
-  const Reviews = useGetReviews(itemKey); //리뷰값 가져오기
-  // console.log(Reviews);
-
-  const [loading, setLoading] = useState(true);
-  useEffect(() => {
-    // orderBookData가 비어 있지 않으면 로딩 상태를 false로 변경
-    if (orderBookData) {
-      setLoading(false);
-    }
-  }, [orderBookData]);
+// 구매하기페이지(Purchase)에서 사용됨
+const PurInfoBox = ({ bookData }) => {
+  // usePurInfoData 훅을 호출하여 sellerData 상태와 데이터 가져오는 로직 사용
+  const { sellerData = {} } = usePurInfoData();  // sellerData를 구조분해할 때 기본값을 설정 => sellerData가 비동기적으로 초기화될 때 undefined가 발생할 수 있기 때문
 
   const navigate = useNavigate();
 
@@ -28,15 +14,11 @@ const PurInfoBox = ({ bookData, orderBookData }) => {
     navigate("/SellerInfoPage", {
       //판매자 정보 페이지로 이동
       state: {
-        custKey: orderBookData.sellerKey,
+        custKey: bookData.sellerKey,
       },
     });
   };
-  // console.log(orderBookData, "전달받은 orderBookData");
 
-  if (loading) {
-    return null; // 로딩 중에는 아무것도 렌더링하지 않음
-  }
   return (
     <div className="yhw_purInfoBox">
       <Link to="/detail">
@@ -53,17 +35,22 @@ const PurInfoBox = ({ bookData, orderBookData }) => {
             title="판매자 정보 보기"
             onClick={convey}
           >
-            판매자: {sellerNickName}
+            판매자: {bookData.seller}
           </span>
         </div>
         <div className="yhw_purInfoTxtBottom">
           <div className="yhw_purInfoStat">
-            <span>구매 날짜</span>
-            <b>{orderBookData.dateBuy.substring(0, 10)}</b>
+            <span>상태 등급</span>
+            <b>
+              {sellerData && sellerData.damage === 0 ? '최상'
+              : sellerData && sellerData.damage === 1 ? '상'
+              : sellerData && sellerData.damage >= 2 ? '중'
+              : '-'}
+            </b>
           </div>
           <div className="yhw_purInfoPrice">
             <span>판매 입찰가</span>
-            <b>{orderBookData.price}원</b>
+            <b>{sellerData && sellerData.price}원</b>
           </div>
         </div>
       </div>

--- a/front_end/src/hooks/api/usePurInfoData.js
+++ b/front_end/src/hooks/api/usePurInfoData.js
@@ -1,35 +1,87 @@
 import { useState, useEffect } from "react";
+import { useParams } from "react-router-dom";
 import axios from 'axios';
 
 const usePurInfoData = () => {
-  const [bookData, setBookData] = useState({
+  const { itemSellKey } = useParams();
+  const itemSellKeyValue = parseInt(itemSellKey, 10); // 문자열을 정수로 변환  
+  console.log("usePurInfoData itemSellKey useParams 확인", itemSellKey);
+  // const [sellerData, setSellerData] = useState([]);
+  const [sellerData, setSellerData] = useState(null); // 초기에 null로 설정
+  const [bookData, setBookData] = useState({  // useState를 객체로 초기화하여 사용
     itemImg: '',
     itemTitle: '',
     author: '',
     publisher: '',
-    seller: '',
-    sellerKey: '',
+    seller: '',     // sellerbook 테이블
+    sellerKey: '',  // sellerbook 테이블
     itemBuyKey: '',
+    itemSellKey: '', // sellerbook 테이블
   });
 
   useEffect(() => {
-    fetchBookData();
+    fetchSellerData();
   }, []);
 
-  const fetchBookData = async () => {
+  // useEffect 훅 내에서 itemSellKey를 확인하여 값이 존재하고 undefined가 아닌 경우에만 fetchSellerData를 호출
+  useEffect(() => {
+    if (sellerData) {
+      fetchBookData(sellerData.itemBuyKey);
+    }
+  }, [sellerData]);
+
+  // 특정 itemSellKey를 통한 조회
+  const fetchSellerData = async () => {
     try {
-      const response = await axios.get('http://localhost:3001/buyerbook');
+      const response = await axios.get(
+        `http://localhost:3001/sellerbook/item/sell/${itemSellKeyValue}`
+      );
       const data = response.data[0];
+
+      setSellerData(data);
+      /*  custKey: 3
+          damage: 2
+          dateEnroll: "2024-04-08T15:00:00.000Z"
+          itemBuyKey: 11
+          itemSellKey: 3
+          price: 12000
+          sellerKey: 1 //판매자의 custKey   */
+
+      // sellerInfo에서 가져온 itemBuyKey를 fetchBookData 함수에 전달
+      fetchBookData(data.itemBuyKey);
+
+    } catch (error) {
+      console.error("Error fetching customers:", error);
+    }
+  };
+
+  // 특정 구매 희망 도서 조회 (Read)
+  const fetchBookData = async (itemBuyKey) => {
+    try {
+      const response = await axios.get(`http://localhost:3001/buyerbook/item/${itemBuyKey}`);
+      const data = response.data[0];  // 응답 데이터 배열에서 첫 번째 요소만을 가져와서 변수 data에 저장
+      // const data = response.data;  // 응답 데이터 자체를 그대로 변수 data에 저장
       const sellerNickname = await getSellerNickname(data.custKey);
-      setBookData({ // 가져온 데이터를 상태로 설정
+      setBookData({
         itemImg: data.itemImg,
         itemTitle: data.itemTitle,
         author: data.author,
         publisher: data.publisher,
         seller: sellerNickname,
-        sellerKey: data.custKey, //판매자의 custKey 추가
+        sellerKey: data.custKey,
         itemBuyKey: data.itemBuyKey,
+        itemSellKey: itemSellKeyValue,
       });
+      /*
+      author: "백난도"
+      itemBuyKey: 4
+      itemImg: "https://shopping-phinf.pstatic.net/main_4444820/44448204620.20231206091808.jpg"
+      itemSellKey: 3
+      itemTitle: "흔한남매 15"
+      publisher: "미래엔아이세움"
+      seller: "testcocomoo"
+      sellerKey: 1
+      */
     } catch (error) {
       console.error('Error fetching book data:', error);
     }
@@ -45,7 +97,7 @@ const usePurInfoData = () => {
     }
   };
   
-  return { bookData, fetchBookData }; // 외부에서 bookData와 fetchBookData를 사용할 수 있도록 반환
+  return { bookData, sellerData }; // 외부에서 bookData와 sellerData를 사용할 수 있도록 반환
 
 }
 

--- a/front_end/src/pages/PurchaseHistory.js
+++ b/front_end/src/pages/PurchaseHistory.js
@@ -4,9 +4,8 @@ import "../styled/PurchaseHistory.css";
 import Header from "../components/Header";
 import MyPageSide from "../components/MypageSide";
 import DateInquiry from "../components/DateInquiry";
-import PurInfoBox from "../components/PurInfoBox";
+import PurHistInfoBox from "../components/PurInfoBox";
 import Footer from "../components/Footer";
-// import usePurInfoData from "../hooks/api/usePurInfoData"; // usePurInfoData 훅 임포트
 import useGetReviews from "../hooks/api/useGetReviews";
 import { LoginContext } from "../components/LoginContext";
 import axios from "axios";
@@ -95,7 +94,7 @@ const PurchaseHistory = () => {
                 <ul className="yhw_purHistLists">
                   {filteredPurLists.map((filteredPurList, index) => (
                     <li key={index}>
-                      <PurInfoBox
+                      <PurHistInfoBox
                         bookData={filteredPurList}
                         orderBookData={orderBookData[index]} // 주문한 도서 정보 전달
                       />


### PR DESCRIPTION
- 구매하기/구매내역페이지 공동 컴포넌트인 PurInfoBox의 데이터 충돌로 인해 구매내역페이지는 PurHistInfoBox를, 구매하기페이지는 PurInfoBox를 사용하도록 수정
- 구매하기페이지 - usePurInfoData 커스텀 훅 DB연결 코드 전체적으로 수정
- 구매하기페이지 : 구매하기 버튼 클릭 시 DB에 저장되게 하는 코드는 아직 구현중입니다.