### PR TITLE
구매하기 기본주소 오류 수정

### DIFF
--- a/front_end/src/components/DestForm.js
+++ b/front_end/src/components/DestForm.js
@@ -4,16 +4,11 @@ import "../styled/DestForm.css";
 import { LoginContext } from "../components/LoginContext";
 import axios from "axios";
 
-const DestForm = ({ isChecked, handleUserAddrChange }) => {
+const DestForm = ({ handleUserAddrChange }) => {
   // 페이지파일(= Purchase.js)에 있는 isChecked를 props로 받아옴
   const { loginUser } = useContext(LoginContext);
-
-  const handleInputChange = (e) => {
-    const { name, value } = e.target;
-    setUserAddr({ ...userAddr, [name]: value });
-    handleUserAddrChange({ ...userAddr, [name]: value });
-  };
   const [user, setUser] = useState([]);
+  const [isChecked, setIsChecked] = useState(false); // 체크하기!!!!!!!!!!!!
   const [userAddr, setUserAddr] = useState({
     custKey: loginUser,
     name: "",
@@ -23,6 +18,47 @@ const DestForm = ({ isChecked, handleUserAddrChange }) => {
     addrDetail: "",
   });
   const [getAddr, setGetAddr] = useState([]);
+
+  const handleInputChange = (e) => {
+    const { name, value } = e.target;
+    console.log(name, value);
+    setUserAddr({ ...userAddr, [name]: value });
+    handleUserAddrChange(userAddr);
+  };
+
+  const defaultAddress = getAddr.find((address) => address.defaultAddr === "Y");
+
+  useEffect(() => {
+    console.log(isChecked, "isChecked 값");
+    console.log(defaultAddress, "defaultAddress 값");
+    if (defaultAddress && isChecked) {
+      setUserAddr({
+        custKey: loginUser,
+        name: defaultAddress.name,
+        tel: defaultAddress.tel,
+        postcode: defaultAddress.postcode,
+        addr: defaultAddress.addr,
+        addrDetail: defaultAddress.addrDetail,
+      });
+      console.log("체크박스 클릭후 디폴트 주소 저장됨:", isChecked);
+      handleUserAddrChange(userAddr);
+    } else {
+      setUserAddr({
+        custKey: loginUser,
+        name: "",
+        tel: "",
+        postcode: "",
+        addr: "",
+        addrDetail: "",
+      });
+      handleUserAddrChange(userAddr);
+      console.log("체크박스 해제후 주소 초기화:", isChecked);
+    }
+  }, [defaultAddress, isChecked]);
+
+  const checked = () => {
+    setIsChecked(!isChecked);
+  };
 
   const getCustomer = async () => {
     try {
@@ -52,117 +88,138 @@ const DestForm = ({ isChecked, handleUserAddrChange }) => {
 
   useEffect(() => {
     getCustomerAddr();
-  }, [user, userAddr]);
+    checked();
+  }, [user]);
 
   return (
-    <form className="yhw_destForm">
-      {/* 주소 목록 출력 */}
-      {getAddr.length > 0 ? (
-        getAddr.map((address, i) =>
-          address.defaultAddr === "Y" ? (
-            <div key={i}>
-              <div className="yhw_destFormInputBox">
-                <label>받는 사람</label>
-                <input
-                  type="text"
-                  name="name"
-                  value={isChecked ? address.name : userAddr.name}
-                  onChange={handleInputChange}
-                />
-              </div>
-              <div className="yhw_destFormInputBox">
-                <label>핸드폰</label>
-                <input
-                  type="text"
-                  name="tel"
-                  // name="phone"
-                  value={isChecked ? address.tel : userAddr.tel}
-                  onChange={handleInputChange}
-                />
-              </div>
-              <div className="yhw_destFormInputBox">
-                <label className="yhw_destFormAddrLabel">주소</label>
-                <div className="yhw_destFomrInputAddrBox">
-                  <div className="yhw_destFormPostBox">
+    <>
+      <div className="yhw_purDefDestCheckForm">
+        <input
+          type="checkbox"
+          value=""
+          id="flexCheckDefault"
+          onChange={checked}
+        />
+        <label htmlFor="flexCheckDefault">새로운 배송지로 배송</label>
+      </div>
+
+      <form className="yhw_destForm">
+        {/* 주소 목록 출력 */}
+        {getAddr.length > 0 ? (
+          getAddr.map((address, i) =>
+            address.defaultAddr === "Y" ? (
+              <>
+                <div key={i}>
+                  <div className="yhw_destFormInputBox">
+                    <label>받는 사람</label>
                     <input
-                      className="yhw_destFormInputPostCode"
-                      type="number"
-                      name="postcode"
-                      // name="postCode"
-                      value={isChecked ? address.postcode : userAddr.postcode}
+                      type="text"
+                      name="name"
+                      value={isChecked ? address.name : userAddr.name}
                       onChange={handleInputChange}
                     />
-                    <span className="yhw_destFormSpanPostCode">우편번호</span>
                   </div>
-                  <input
-                    type="text"
-                    name="addr"
-                    // name="address"
-                    value={isChecked ? address.addr : userAddr.addr}
-                    onChange={handleInputChange}
-                  />
-                  <input
-                    type="text"
-                    name="addrDetail"
-                    // name="detailAddress"
-                    value={isChecked ? address.addrDetail : userAddr.addrDetail}
-                    onChange={handleInputChange}
-                  />
+                  <div className="yhw_destFormInputBox">
+                    <label>핸드폰</label>
+                    <input
+                      type="text"
+                      name="tel"
+                      // name="phone"
+                      value={isChecked ? address.tel : userAddr.tel}
+                      onChange={handleInputChange}
+                    />
+                  </div>
+                  <div className="yhw_destFormInputBox">
+                    <label className="yhw_destFormAddrLabel">주소</label>
+                    <div className="yhw_destFomrInputAddrBox">
+                      <div className="yhw_destFormPostBox">
+                        <input
+                          className="yhw_destFormInputPostCode"
+                          type="number"
+                          name="postcode"
+                          // name="postCode"
+                          value={
+                            isChecked ? address.postcode : userAddr.postcode
+                          }
+                          onChange={handleInputChange}
+                        />
+                        <span className="yhw_destFormSpanPostCode">
+                          우편번호
+                        </span>
+                      </div>
+                      <input
+                        type="text"
+                        name="addr"
+                        // name="address"
+                        value={isChecked ? address.addr : userAddr.addr}
+                        onChange={handleInputChange}
+                      />
+                      <input
+                        type="text"
+                        name="addrDetail"
+                        // name="detailAddress"
+                        value={
+                          isChecked ? address.addrDetail : userAddr.addrDetail
+                        }
+                        onChange={handleInputChange}
+                      />
+                    </div>
+                  </div>
                 </div>
-              </div>
+              </>
+            ) : null
+          )
+        ) : (
+          <>
+            <div className="yhw_destFormInputBox">
+              <label>받는 사람</label>
+              <input
+                type="text"
+                name="name"
+                value={userAddr.name}
+                onChange={handleInputChange}
+              />
             </div>
-          ) : null
-        )
-      ) : (
-        <>
-          <div className="yhw_destFormInputBox">
-            <label>받는 사람</label>
-            <input
-              type="text"
-              name="name"
-              value={userAddr.name}
-              onChange={handleInputChange}
-            />
-          </div>
-          <div className="yhw_destFormInputBox">
-            <label>핸드폰</label>
-            <input
-              type="text"
-              name="phone"
-              value={userAddr.tel}
-              onChange={handleInputChange}
-            />
-          </div>
-          <div className="yhw_destFormInputBox">
-            <label className="yhw_destFormAddrLabel">주소</label>
-            <div className="yhw_destFomrInputAddrBox">
-              <div className="yhw_destFormPostBox">
+            <div className="yhw_destFormInputBox">
+              <label>핸드폰</label>
+              <input
+                type="text"
+                name="tel"
+                value={userAddr.tel}
+                onChange={handleInputChange}
+              />
+            </div>
+            <div className="yhw_destFormInputBox">
+              <label className="yhw_destFormAddrLabel">주소</label>
+              <div className="yhw_destFomrInputAddrBox">
+                <div className="yhw_destFormPostBox">
+                  <input
+                    className="yhw_destFormInputPostCode"
+                    type="number"
+                    name="postCode"
+                    value={userAddr.postcode}
+                    onChange={handleInputChange}
+                  />
+                  <span className="yhw_destFormSpanPostCode">우편번호</span>
+                </div>
                 <input
-                  className="yhw_destFormInputPostCode"
-                  type="number"
-                  name="postCode"
-                  value={userAddr.postcode}
+                  type="text"
+                  name="address"
+                  value={userAddr.addr}
                   onChange={handleInputChange}
                 />
-                <span className="yhw_destFormSpanPostCode">우편번호</span>
+                <input
+                  type="text"
+                  name="detailAddress"
+                  value={userAddr.addrDetail}
+                  onChange={handleInputChange}
+                />
               </div>
-              <input
-                type="text"
-                name="address"
-                value={userAddr.addr}
-                onChange={handleInputChange}
-              />
-              <input
-                type="text"
-                name="detailAddress"
-                value={userAddr.addrDetail}
-                onChange={handleInputChange}
-              />
             </div>
-          </div>
-        </>
-      )}
-    </form>
+          </>
+        )}
+      </form>
+    </>
   );
 };
 

--- a/front_end/src/components/PurInfoBox.js
+++ b/front_end/src/components/PurInfoBox.js
@@ -2,19 +2,14 @@ import React, { useState, useEffect } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import "../styled/PurInfoBox.css";
 import useSellerNickname from "../hooks/api/useSellerNickname";
-import useGetReviews from "../hooks/api/useGetReviews";
 
 const PurInfoBox = ({ bookData, orderBookData }) => {
   // orderBookData가 존재하고 유효한 경우에만 판매자 닉네임을 가져오도록 설정
   const sellerKey = orderBookData ? orderBookData.sellerKey : null;
   const sellerNickName = useSellerNickname(sellerKey);
-  const itemKey = orderBookData ? orderBookData.itemKey : null;
-
-  //========== 리뷰값 가져오기 =========//
-  const Reviews = useGetReviews(itemKey); //리뷰값 가져오기
-  // console.log(Reviews);
-
   const [loading, setLoading] = useState(true);
+  // 주문한 도서 정보 요청
+
   useEffect(() => {
     // orderBookData가 비어 있지 않으면 로딩 상태를 false로 변경
     if (orderBookData) {
@@ -32,11 +27,11 @@ const PurInfoBox = ({ bookData, orderBookData }) => {
       },
     });
   };
-  console.log(orderBookData, "전달받은 orderBookData");
 
   if (loading) {
     return null; // 로딩 중에는 아무것도 렌더링하지 않음
   }
+
   return (
     <div className="yhw_purInfoBox">
       <Link to="/detail">
@@ -61,10 +56,10 @@ const PurInfoBox = ({ bookData, orderBookData }) => {
             <span>구매 날짜</span>
             <b>{orderBookData.dateBuy.substring(0, 10)}</b>
           </div>
-          <div className="yhw_purInfoPrice">
+          {/* <div className="yhw_purInfoPrice">
             <span>판매 입찰가</span>
-            <b>{orderBookData.price}원</b>
-          </div>
+            <b>{sellerPrice}원</b>
+          </div> */}
         </div>
       </div>
     </div>

--- a/front_end/src/pages/Purchase.js
+++ b/front_end/src/pages/Purchase.js
@@ -4,7 +4,7 @@ import axios from "axios";
 import "../styled/Purchase.css";
 import Header from "../components/Header";
 import PurInfoBoxForPur from "../components/PurInfoBoxForPur";
-import PurDefDestCheck from "../components/DefDestCheck";
+// import PurDefDestCheck from "../components/DefDestCheck";
 import PurDefDest from "../components/PurDefDest";
 import DestForm from "../components/DestForm";
 import Footer from "../components/Footer";
@@ -17,12 +17,9 @@ const Purchase = () => {
   const itemSellKey = params.itemSellKey;
   // console.log(itemSellyKey, "itemSellyKey");
   const bookData = useBookDataByItemSellKey(itemSellKey);
-
-  console.log(bookData, "bookData 데이터");
-
+  // console.log(bookData, "bookData 데이터");
   const userInfo = useBuyerInformation(bookData.itemBuyKey);
-  // console.log(userInfo, "userInfo");
-  const [isChecked, setIsChecked] = useState(false);
+
   const [addInfo, setAddinfo] = useState({
     sellerKey: "",
     price: "",
@@ -56,7 +53,14 @@ const Purchase = () => {
   // 구매하기 버튼 클릭 시 해당 도서 Purchase 페이지로 이동하는 함수
   const handlePurBtnClick = async (e) => {
     e.preventDefault();
+
     console.log(updatedAddr, "업데이트된 주소값");
+    if (updatedAddr.addr === "") {
+      alert(
+        "요청을 처리하는 중에 문제가 발생했습니다. 나중에 다시 시도하거나 지원팀에 문의하여 주십시오."
+      );
+      navigate("/Mypage/RegRequest");
+    }
     try {
       // Make a POST request using Axios
       const response = await axios.post(
@@ -79,9 +83,11 @@ const Purchase = () => {
 
     window.scrollTo(0, 0); // 페이지 이동 후 화면의 상단으로 스크롤 이동
   };
-  const handleUserAddrChange = (newAddr) => {
-    setUserAddr(newAddr); // Update userAddr state with new address data from DestForm
-    console.log(newAddr);
+
+  const handleUserAddrChange = (newAddress) => {
+    // 1. 매개변수로 전달된 새로운 주소 정보를 출력하여 확인
+    console.log("New Address:", newAddress);
+    setUserAddr(newAddress); // Update userAddr state with new address data from DestForm
   };
   return (
     <>
@@ -98,18 +104,11 @@ const Purchase = () => {
           </div>
           <div className="yhw_purDefDestCont">
             <div className="yhw_purDefDestBox">
-              <PurDefDestCheck
-                isChecked={isChecked}
-                setIsChecked={setIsChecked}
-              />
               <PurDefDest />
             </div>
           </div>
           <div className="yhw_destFormDiv">
-            <DestForm
-              isChecked={isChecked}
-              handleUserAddrChange={handleUserAddrChange}
-            />
+            <DestForm handleUserAddrChange={handleUserAddrChange} />
           </div>
           <button className="yhw_purBtn" onClick={handlePurBtnClick}>
             구매하기


### PR DESCRIPTION
- 구매하기 페이지에서 기본주소 사용을 디폴트로 설정.
- 새로운 주소 사용하기 체크시 빈 Form이 되고, 새로운 주소 입력후 주문하기 누르면 DB에저장.
- 구매하기 눌렀을때 주소가 비어있으면 오류메시지 띄우고 구매희망 도서 페이지로 이동.